### PR TITLE
Speed up adler32.Write

### DIFF
--- a/adler32/adler32_test.go
+++ b/adler32/adler32_test.go
@@ -124,7 +124,7 @@ func TestBlackBox(t *testing.T) {
 }
 
 func BenchmarkRollingKB(b *testing.B) {
-	b.SetBytes(1024)
+	b.SetBytes(1)
 	window := make([]byte, 1024)
 	rand.Read(window)
 
@@ -139,8 +139,25 @@ func BenchmarkRollingKB(b *testing.B) {
 	}
 }
 
-func BenchmarkRolling128B(b *testing.B) {
+func BenchmarkWriteKB(b *testing.B) {
 	b.SetBytes(1024)
+	b.ReportAllocs()
+	window := make([]byte, 1024)
+	rand.Read(window)
+
+	h := rollsum.New()
+	in := make([]byte, 0, h.Size())
+
+	b.ResetTimer()
+	h.Write(window)
+	for i := 0; i < b.N; i++ {
+		h.Write(window)
+		h.Sum(in)
+	}
+}
+
+func BenchmarkRolling128B(b *testing.B) {
+	b.SetBytes(1)
 	window := make([]byte, 128)
 	rand.Read(window)
 


### PR DESCRIPTION
Write() used to allocate both a full copy of the passed data and a new vanilla hasher. This removes both allocations in the common case and increases throughput by about 36% as a result. It makes this adler32.Write() comparable in performance to the vanilla hash/adler32.Write().

            benchmark              old ns/op     new ns/op     delta
            BenchmarkWriteKB-8     647           476           -26.43%
    
            benchmark              old MB/s     new MB/s     speedup
            BenchmarkWriteKB-8     1582.46      2148.24      1.36x
    
            benchmark              old allocs     new allocs     delta
            BenchmarkWriteKB-8     2              0              -100.00%
    
            benchmark              old bytes     new bytes     delta
            BenchmarkWriteKB-8     1028          0             -100.00%
