### PR TITLE
Allow access to Adler-32's internal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ of the byte exiting the window. It can be accessed through the
 [`io.Reader`](https://golang.org/pkg/io/#Reader) interface of the hash.
 
 ```golang
-// err is always nil
-window, _ := ioutil.ReadAll(h)
+var buf bytes.Buffer
+// The error is always nil for a bytes.Buffer.
+h.WriteWindow(&buf)
+window := buf.Bytes()
 ```
 
 Gotchas

--- a/adler32/adler32_test.go
+++ b/adler32/adler32_test.go
@@ -69,7 +69,6 @@ var (
 	_ hash.Hash32        = rollsum.New()
 	_ rollinghash.Hash32 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum32ByWriteAndRoll computes the sum by prepending the input slice with

--- a/bozo32/bozo32.go
+++ b/bozo32/bozo32.go
@@ -56,16 +56,19 @@ func (d *Bozo32) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Bozo32) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Bozo32) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
+// WriteWindow writes the contents of the current window to w.
+func (d *Bozo32) WriteWindow(w io.Writer) (n int, err error) {
+	// Copy the older bytes.
+	if d.oldest < len(d.window) {
+		n, err = w.Write(d.window[d.oldest:])
 	}
-	return n, io.EOF
+	// Then the newer bytes.
+	if err == nil && d.oldest > 0 {
+		var n2 int
+		n2, err = w.Write(d.window[:d.oldest])
+		n += n2
+	}
+	return
 }
 
 // Write appends data to the rolling window and updates the digest. It

--- a/bozo32/bozo32_test.go
+++ b/bozo32/bozo32_test.go
@@ -67,7 +67,6 @@ var (
 	_ hash.Hash32        = rollsum.New()
 	_ rollinghash.Hash32 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum32ByWriteAndRoll computes the sum by prepending the input slice with

--- a/buzhash32/buzhash32.go
+++ b/buzhash32/buzhash32.go
@@ -78,16 +78,19 @@ func (d *Buzhash32) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Buzhash32) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Buzhash32) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
+// WriteWindow writes the contents of the current window to w.
+func (d *Buzhash32) WriteWindow(w io.Writer) (n int, err error) {
+	// Copy the older bytes.
+	if d.oldest < len(d.window) {
+		n, err = w.Write(d.window[d.oldest:])
 	}
-	return n, io.EOF
+	// Then the newer bytes.
+	if err == nil && d.oldest > 0 {
+		var n2 int
+		n2, err = w.Write(d.window[:d.oldest])
+		n += n2
+	}
+	return
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/buzhash32/buzhash32_test.go
+++ b/buzhash32/buzhash32_test.go
@@ -67,7 +67,6 @@ var (
 	_ hash.Hash32        = rollsum.New()
 	_ rollinghash.Hash32 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum32ByWriteAndRoll computes the sum by prepending the input slice with

--- a/buzhash64/buzhash64.go
+++ b/buzhash64/buzhash64.go
@@ -78,16 +78,19 @@ func (d *Buzhash64) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Buzhash64) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Buzhash64) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
+// WriteWindow writes the contents of the current window to w.
+func (d *Buzhash64) WriteWindow(w io.Writer) (n int, err error) {
+	// Copy the older bytes.
+	if d.oldest < len(d.window) {
+		n, err = w.Write(d.window[d.oldest:])
 	}
-	return n, io.EOF
+	// Then the newer bytes.
+	if err == nil && d.oldest > 0 {
+		var n2 int
+		n2, err = w.Write(d.window[:d.oldest])
+		n += n2
+	}
+	return
 }
 
 // Write appends data to the rolling window and updates the digest. It

--- a/buzhash64/buzhash64_test.go
+++ b/buzhash64/buzhash64_test.go
@@ -67,7 +67,6 @@ var (
 	_ hash.Hash64        = rollsum.New()
 	_ rollinghash.Hash64 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum64ByWriteAndRoll computes the sum by prepending the input slice with

--- a/rabinkarp64/rabinkarp64.go
+++ b/rabinkarp64/rabinkarp64.go
@@ -175,16 +175,19 @@ func (d *RabinKarp64) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *RabinKarp64) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *RabinKarp64) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
+// WriteWindow writes the contents of the current window to w.
+func (d *RabinKarp64) WriteWindow(w io.Writer) (n int, err error) {
+	// Copy the older bytes.
+	if d.oldest < len(d.window) {
+		n, err = w.Write(d.window[d.oldest:])
 	}
-	return n, io.EOF
+	// Then the newer bytes.
+	if err == nil && d.oldest > 0 {
+		var n2 int
+		n2, err = w.Write(d.window[:d.oldest])
+		n += n2
+	}
+	return
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/rabinkarp64/rabinkarp64_test.go
+++ b/rabinkarp64/rabinkarp64_test.go
@@ -69,7 +69,6 @@ var (
 	_ hash.Hash64        = rollsum.New()
 	_ rollinghash.Hash64 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum64ByWriteAndRoll computes the sum by prepending the input slice with

--- a/rollinghash.go
+++ b/rollinghash.go
@@ -24,6 +24,12 @@ const DefaultWindowCap = 64
 // every time Roll() is called.
 type Roller interface {
 	Roll(b byte)
+
+	// WriteWindow writes the contents of the current window to w.
+	//
+	// It returns the number of bytes written and any error returned by
+	// w.Write.
+	WriteWindow(w io.Writer) (int, error)
 }
 
 // rollinghash.Hash extends hash.Hash by adding the method Roll. A
@@ -35,7 +41,6 @@ type Roller interface {
 // accessed through the io.Reader interface.
 type Hash interface {
 	hash.Hash
-	io.Reader
 	Roller
 }
 
@@ -48,7 +53,6 @@ type Hash interface {
 // accessed through the io.Reader interface.
 type Hash32 interface {
 	hash.Hash32
-	io.Reader
 	Roller
 }
 
@@ -61,6 +65,5 @@ type Hash32 interface {
 // accessed through the io.Reader interface.
 type Hash64 interface {
 	hash.Hash64
-	io.Reader
 	Roller
 }

--- a/rollinghash_test.go
+++ b/rollinghash_test.go
@@ -1,8 +1,8 @@
 package rollinghash_test
 
 import (
+	"bytes"
 	"hash"
-	"io/ioutil"
 	"math/rand"
 	"testing"
 
@@ -167,43 +167,50 @@ func writeNothing(t *testing.T, hashname string, classic hash.Hash, rolling roll
 func read(t *testing.T, hashname string, rolling rollinghash.Hash) {
 	rolling.Write([]byte("hello "))
 
+	var buf bytes.Buffer
+	readWindow := func() []byte {
+		buf.Reset()
+		rolling.WriteWindow(&buf)
+		return buf.Bytes()
+	}
+
 	rolling.Roll(byte('w'))
-	window, _ := ioutil.ReadAll(rolling)
+	window := readWindow()
 	expected := "ello w"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('o'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = readWindow()
 	expected = "llo wo"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('r'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = readWindow()
 	expected = "lo wor"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('l'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = readWindow()
 	expected = "o worl"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('d'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = readWindow()
 	expected = " world"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('!'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = readWindow()
 	expected = "world!"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)


### PR DESCRIPTION
This PR adds a WriteTo method to Adler32 that allows clients to obtain a copy of its rolling window. This is useful for Syncthing and other applications that want to inspect/use the parts of a file that match a given hash.

This could probably be done for more hashes, but Adler-32 is the one used by Syncthing.