### PR TITLE
Replace Read method with Window method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,8 @@ Accessing the rolling window
 A
 [`rollinghash.Hash`](https://godoc.org/github.com/chmduquesne/rollinghash#Hash)
 maintains a copy of the rolling window in order to keep track of the value
-of the byte exiting the window. It can be accessed through the
-[`io.Reader`](https://golang.org/pkg/io/#Reader) interface of the hash.
-
-```golang
-// err is always nil
-window, _ := ioutil.ReadAll(h)
-```
+of the byte exiting the window. It can be accessed through the `Window`
+method on the hash.
 
 Gotchas
 -------

--- a/adler32/adler32.go
+++ b/adler32/adler32.go
@@ -5,7 +5,6 @@ package adler32
 import (
 	"hash"
 	vanilla "hash/adler32"
-	"io"
 
 	"github.com/chmduquesne/rollinghash"
 )
@@ -57,16 +56,11 @@ func (d *Adler32) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Adler32) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Adler32) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
-	}
-	return n, io.EOF
+// Window appends the content of the rolling window to p and returns the result.
+func (d *Adler32) Window(p []byte) []byte {
+	p = append(p, d.window[d.oldest:]...)
+	p = append(p, d.window[:d.oldest]...)
+	return p
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/adler32/adler32_test.go
+++ b/adler32/adler32_test.go
@@ -69,7 +69,6 @@ var (
 	_ hash.Hash32        = rollsum.New()
 	_ rollinghash.Hash32 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum32ByWriteAndRoll computes the sum by prepending the input slice with

--- a/adler32/doc_test.go
+++ b/adler32/doc_test.go
@@ -32,7 +32,9 @@ func Example() {
 		// Roll the incoming byte in rolling
 		rolling.Roll(s[i])
 
-		fmt.Printf("%v: checksum %x\n", string(s[i-n+1:i+1]), rolling.Sum32())
+		// Retrieve the current window
+		win := string(rolling.Window(nil))
+		fmt.Printf("%v: checksum %x\n", win, rolling.Sum32())
 
 		// Compare the hashes
 		if classic.Sum32() != rolling.Sum32() {

--- a/bozo32/bozo32.go
+++ b/bozo32/bozo32.go
@@ -7,11 +7,7 @@
 
 package bozo32
 
-import (
-	"io"
-
-	rollinghash "github.com/chmduquesne/rollinghash"
-)
+import rollinghash "github.com/chmduquesne/rollinghash"
 
 // The size of the checksum.
 const Size = 4
@@ -56,16 +52,11 @@ func (d *Bozo32) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Bozo32) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Bozo32) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
-	}
-	return n, io.EOF
+// Window appends the content of the rolling window to p and returns the result.
+func (d *Bozo32) Window(p []byte) []byte {
+	p = append(p, d.window[d.oldest:]...)
+	p = append(p, d.window[:d.oldest]...)
+	return p
 }
 
 // Write appends data to the rolling window and updates the digest. It

--- a/bozo32/bozo32_test.go
+++ b/bozo32/bozo32_test.go
@@ -67,7 +67,6 @@ var (
 	_ hash.Hash32        = rollsum.New()
 	_ rollinghash.Hash32 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum32ByWriteAndRoll computes the sum by prepending the input slice with

--- a/buzhash32/buzhash32.go
+++ b/buzhash32/buzhash32.go
@@ -4,7 +4,6 @@
 package buzhash32
 
 import (
-	"io"
 	"math/rand"
 
 	rollinghash "github.com/chmduquesne/rollinghash"
@@ -78,16 +77,11 @@ func (d *Buzhash32) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Buzhash32) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Buzhash32) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
-	}
-	return n, io.EOF
+// Window appends the content of the rolling window to p and returns the result.
+func (d *Buzhash32) Window(p []byte) []byte {
+	p = append(p, d.window[d.oldest:]...)
+	p = append(p, d.window[:d.oldest]...)
+	return p
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/buzhash32/buzhash32_test.go
+++ b/buzhash32/buzhash32_test.go
@@ -67,7 +67,6 @@ var (
 	_ hash.Hash32        = rollsum.New()
 	_ rollinghash.Hash32 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum32ByWriteAndRoll computes the sum by prepending the input slice with

--- a/buzhash64/buzhash64.go
+++ b/buzhash64/buzhash64.go
@@ -4,7 +4,6 @@
 package buzhash64
 
 import (
-	"io"
 	"math/rand"
 
 	"github.com/chmduquesne/rollinghash"
@@ -78,16 +77,11 @@ func (d *Buzhash64) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Buzhash64) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *Buzhash64) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
-	}
-	return n, io.EOF
+// Window appends the content of the rolling window to p and returns the result.
+func (d *Buzhash64) Window(p []byte) []byte {
+	p = append(p, d.window[d.oldest:]...)
+	p = append(p, d.window[:d.oldest]...)
+	return p
 }
 
 // Write appends data to the rolling window and updates the digest. It

--- a/buzhash64/buzhash64_test.go
+++ b/buzhash64/buzhash64_test.go
@@ -67,7 +67,6 @@ var (
 	_ hash.Hash64        = rollsum.New()
 	_ rollinghash.Hash64 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum64ByWriteAndRoll computes the sum by prepending the input slice with

--- a/rabinkarp64/rabinkarp64.go
+++ b/rabinkarp64/rabinkarp64.go
@@ -29,7 +29,6 @@
 package rabinkarp64
 
 import (
-	"io"
 	"sync"
 
 	"github.com/chmduquesne/rollinghash"
@@ -175,16 +174,11 @@ func (d *RabinKarp64) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *RabinKarp64) BlockSize() int { return 1 }
 
-// Read reads the content of the rolling window into p. The error returned
-// is always io.EOF
-func (d *RabinKarp64) Read(p []byte) (int, error) {
-	// Copy the newer bytes
-	n := copy(p, d.window[d.oldest:])
-	// If there is space left, also copy the older bytes
-	if n < len(p) {
-		n += copy(p[n:], d.window[:d.oldest])
-	}
-	return n, io.EOF
+// Window appends the content of the rolling window to p and returns the result.
+func (d *RabinKarp64) Window(p []byte) []byte {
+	p = append(p, d.window[d.oldest:]...)
+	p = append(p, d.window[:d.oldest]...)
+	return p
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/rabinkarp64/rabinkarp64_test.go
+++ b/rabinkarp64/rabinkarp64_test.go
@@ -69,7 +69,6 @@ var (
 	_ hash.Hash64        = rollsum.New()
 	_ rollinghash.Hash64 = rollsum.New()
 	_ io.Writer          = rollsum.New()
-	_ io.Reader          = rollsum.New()
 )
 
 // Sum64ByWriteAndRoll computes the sum by prepending the input slice with

--- a/rollinghash.go
+++ b/rollinghash.go
@@ -5,10 +5,7 @@ Package rollinghash implements rolling versions of some hashes
 */
 package rollinghash
 
-import (
-	"hash"
-	"io"
-)
+import "hash"
 
 // DefaultWindowCap is the default capacity of the internal window of a
 // new Hash.
@@ -31,12 +28,14 @@ type Roller interface {
 // enters the window.
 // A rollinghash.Hash internally maintains a copy of the rolling window in
 // order to keep track of the value of the byte exiting the window. This
-// copy is updated with every call to Roll. The rolling window can be
-// accessed through the io.Reader interface.
+// copy is updated with every call to Roll.
 type Hash interface {
 	hash.Hash
-	io.Reader
 	Roller
+
+	// Window appends the current contents of the rolling window to its
+	// argument and returns the result.
+	Window([]byte) []byte
 }
 
 // rollinghash.Hash32 extends hash.Hash by adding the method Roll. A
@@ -44,12 +43,14 @@ type Hash interface {
 // byte enters the window.
 // A rollinghash.Hash32 internally maintains a copy of the rolling window in
 // order to keep track of the value of the byte exiting the window. This
-// copy is updated with every call to Roll. The rolling window can be
-// accessed through the io.Reader interface.
+// copy is updated with every call to Roll.
 type Hash32 interface {
 	hash.Hash32
-	io.Reader
 	Roller
+
+	// Window appends the current contents of the rolling window to its
+	// argument and returns the result.
+	Window([]byte) []byte
 }
 
 // rollinghash.Hash64 extends hash.Hash by adding the method Roll. A
@@ -61,6 +62,9 @@ type Hash32 interface {
 // accessed through the io.Reader interface.
 type Hash64 interface {
 	hash.Hash64
-	io.Reader
 	Roller
+
+	// Window appends the current contents of the rolling window to its
+	// argument and returns the result.
+	Window([]byte) []byte
 }

--- a/rollinghash_test.go
+++ b/rollinghash_test.go
@@ -2,7 +2,6 @@ package rollinghash_test
 
 import (
 	"hash"
-	"io/ioutil"
 	"math/rand"
 	"testing"
 
@@ -168,42 +167,42 @@ func read(t *testing.T, hashname string, rolling rollinghash.Hash) {
 	rolling.Write([]byte("hello "))
 
 	rolling.Roll(byte('w'))
-	window, _ := ioutil.ReadAll(rolling)
+	window := rolling.Window(nil)
 	expected := "ello w"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('o'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = rolling.Window(window[:0])
 	expected = "llo wo"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('r'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = rolling.Window(window[:0])
 	expected = "lo wor"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('l'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = rolling.Window(window[:0])
 	expected = "o worl"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('d'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = rolling.Window(window[:0])
 	expected = " world"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)
 	}
 
 	rolling.Roll(byte('!'))
-	window, _ = ioutil.ReadAll(rolling)
+	window = rolling.Window(window[:0])
 	expected = "world!"
 	if string(window) != expected {
 		t.Errorf("[%s] Expected the window to be '%s'", hashname, expected)


### PR DESCRIPTION
Alternative to #9 with a simple method for getting the rolling window. It takes a single argument so that client code can do its own memory allocation:

```
var window []byte
for {
	if h.Sum32() == hashToSearchFor {
		window = h.Window(window[:0]) // only allocates on the first match
		// do something with window
	}
}
```