### PR TITLE
Make rollinghash a Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/chmduquesne/rollinghash
+
+go 1.9
+
+require code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48 h1:/EMHruHCFXR9xClkGV/t0rmHrdhX4+trQUcBqjwc9xE=
+code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48/go.mod h1:wN/zk7mhREp/oviagqUXY3EwuHhWyOvAdsn5Y4CzOrc=


### PR DESCRIPTION
Since the roll command has a dependency, it's not currently possible to do `go test ./...` unless code.cloudfoundry.org/bytefmt is in the GOPATH somewhere. go.mod fixes that.