### PR TITLE
Refactoring + optimization

### DIFF
--- a/adler32/adler32.go
+++ b/adler32/adler32.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash/internal/window"
 )
 
 const (
@@ -59,17 +60,7 @@ func (d *Adler32) BlockSize() int { return 1 }
 
 // WriteWindow writes the contents of the current window to w.
 func (d *Adler32) WriteWindow(w io.Writer) (n int, err error) {
-	// Copy the older bytes.
-	if d.oldest < len(d.window) {
-		n, err = w.Write(d.window[d.oldest:])
-	}
-	// Then the newer bytes.
-	if err == nil && d.oldest > 0 {
-		var n2 int
-		n2, err = w.Write(d.window[:d.oldest])
-		n += n2
-	}
-	return
+	return window.Write(w, d.window, d.oldest)
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/adler32/adler32.go
+++ b/adler32/adler32.go
@@ -70,12 +70,8 @@ func (d *Adler32) Write(data []byte) (int, error) {
 		return 0, nil
 	}
 	// Re-arrange the window so that the leftmost element is at index 0
-	n := len(d.window)
 	if d.oldest != 0 {
-		tmp := make([]byte, d.oldest)
-		copy(tmp, d.window[:d.oldest])
-		copy(d.window, d.window[d.oldest:])
-		copy(d.window[n-d.oldest:], tmp)
+		window.MoveLeft(d.window, d.oldest)
 		d.oldest = 0
 	}
 	d.window = append(d.window, data...)

--- a/bozo32/bozo32.go
+++ b/bozo32/bozo32.go
@@ -10,7 +10,8 @@ package bozo32
 import (
 	"io"
 
-	rollinghash "github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash/internal/window"
 )
 
 // The size of the checksum.
@@ -58,17 +59,7 @@ func (d *Bozo32) BlockSize() int { return 1 }
 
 // WriteWindow writes the contents of the current window to w.
 func (d *Bozo32) WriteWindow(w io.Writer) (n int, err error) {
-	// Copy the older bytes.
-	if d.oldest < len(d.window) {
-		n, err = w.Write(d.window[d.oldest:])
-	}
-	// Then the newer bytes.
-	if err == nil && d.oldest > 0 {
-		var n2 int
-		n2, err = w.Write(d.window[:d.oldest])
-		n += n2
-	}
-	return
+	return window.Write(w, d.window, d.oldest)
 }
 
 // Write appends data to the rolling window and updates the digest. It

--- a/bozo32/bozo32.go
+++ b/bozo32/bozo32.go
@@ -70,12 +70,8 @@ func (d *Bozo32) Write(data []byte) (int, error) {
 		return 0, nil
 	}
 	// Re-arrange the window so that the leftmost element is at index 0
-	n := len(d.window)
 	if d.oldest != 0 {
-		tmp := make([]byte, d.oldest)
-		copy(tmp, d.window[:d.oldest])
-		copy(d.window, d.window[d.oldest:])
-		copy(d.window[n-d.oldest:], tmp)
+		window.MoveLeft(d.window, d.oldest)
 		d.oldest = 0
 	}
 	d.window = append(d.window, data...)

--- a/buzhash32/buzhash32.go
+++ b/buzhash32/buzhash32.go
@@ -7,7 +7,8 @@ import (
 	"io"
 	"math/rand"
 
-	rollinghash "github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash/internal/window"
 )
 
 var defaultHashes [256]uint32
@@ -80,17 +81,7 @@ func (d *Buzhash32) BlockSize() int { return 1 }
 
 // WriteWindow writes the contents of the current window to w.
 func (d *Buzhash32) WriteWindow(w io.Writer) (n int, err error) {
-	// Copy the older bytes.
-	if d.oldest < len(d.window) {
-		n, err = w.Write(d.window[d.oldest:])
-	}
-	// Then the newer bytes.
-	if err == nil && d.oldest > 0 {
-		var n2 int
-		n2, err = w.Write(d.window[:d.oldest])
-		n += n2
-	}
-	return
+	return window.Write(w, d.window, d.oldest)
 }
 
 // Write appends data to the rolling window and updates the digest.

--- a/buzhash32/buzhash32.go
+++ b/buzhash32/buzhash32.go
@@ -91,12 +91,8 @@ func (d *Buzhash32) Write(data []byte) (int, error) {
 		return 0, nil
 	}
 	// Re-arrange the window so that the leftmost element is at index 0
-	n := len(d.window)
 	if d.oldest != 0 {
-		tmp := make([]byte, d.oldest)
-		copy(tmp, d.window[:d.oldest])
-		copy(d.window, d.window[d.oldest:])
-		copy(d.window[n-d.oldest:], tmp)
+		window.MoveLeft(d.window, d.oldest)
 		d.oldest = 0
 	}
 	d.window = append(d.window, data...)

--- a/buzhash64/buzhash64.go
+++ b/buzhash64/buzhash64.go
@@ -92,12 +92,8 @@ func (d *Buzhash64) Write(data []byte) (int, error) {
 		return 0, nil
 	}
 	// Re-arrange the window so that the leftmost element is at index 0
-	n := len(d.window)
 	if d.oldest != 0 {
-		tmp := make([]byte, d.oldest)
-		copy(tmp, d.window[:d.oldest])
-		copy(d.window, d.window[d.oldest:])
-		copy(d.window[n-d.oldest:], tmp)
+		window.MoveLeft(d.window, d.oldest)
 		d.oldest = 0
 	}
 	d.window = append(d.window, data...)

--- a/buzhash64/buzhash64.go
+++ b/buzhash64/buzhash64.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 
 	"github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash/internal/window"
 )
 
 var defaultHashes [256]uint64
@@ -80,17 +81,7 @@ func (d *Buzhash64) BlockSize() int { return 1 }
 
 // WriteWindow writes the contents of the current window to w.
 func (d *Buzhash64) WriteWindow(w io.Writer) (n int, err error) {
-	// Copy the older bytes.
-	if d.oldest < len(d.window) {
-		n, err = w.Write(d.window[d.oldest:])
-	}
-	// Then the newer bytes.
-	if err == nil && d.oldest > 0 {
-		var n2 int
-		n2, err = w.Write(d.window[:d.oldest])
-		n += n2
-	}
-	return
+	return window.Write(w, d.window, d.oldest)
 }
 
 // Write appends data to the rolling window and updates the digest. It

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -1,0 +1,18 @@
+// Package window provides common code for dealing with sliding windows.
+package window
+
+import "io"
+
+func Write(w io.Writer, window []byte, oldest int) (n int, err error) {
+	// Copy the older bytes.
+	if oldest < len(window) {
+		n, err = w.Write(window[oldest:])
+	}
+	// Then the newer bytes.
+	if err == nil && oldest > 0 {
+		var n2 int
+		n2, err = w.Write(window[:oldest])
+		n += n2
+	}
+	return
+}

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -3,6 +3,22 @@ package window
 
 import "io"
 
+// MoveLeft re-arranges window so that the oldest element is at index 0.
+func MoveLeft(window []byte, oldest int) {
+	// This is the old swap-by-reverse trick (see Programming Pearls):
+	// R(a)+R(b) = R(b+a), so b+a = R(R(a)+R(b)).
+	reverse(window[:oldest])
+	reverse(window[oldest:])
+	reverse(window)
+}
+
+func reverse(w []byte) {
+	for i := 0; i < len(w)/2; i++ {
+		j := len(w) - i - 1
+		w[i], w[j] = w[j], w[i]
+	}
+}
+
 func Write(w io.Writer, window []byte, oldest int) (n int, err error) {
 	// Copy the older bytes.
 	if oldest < len(window) {

--- a/rabinkarp64/rabinkarp64.go
+++ b/rabinkarp64/rabinkarp64.go
@@ -188,12 +188,8 @@ func (d *RabinKarp64) Write(data []byte) (int, error) {
 		return 0, nil
 	}
 	// Re-arrange the window so that the leftmost element is at index 0
-	n := len(d.window)
 	if d.oldest != 0 {
-		tmp := make([]byte, d.oldest)
-		copy(tmp, d.window[:d.oldest])
-		copy(d.window, d.window[d.oldest:])
-		copy(d.window[n-d.oldest:], tmp)
+		window.MoveLeft(d.window, d.oldest)
 		d.oldest = 0
 	}
 	d.window = append(d.window, data...)

--- a/rabinkarp64/rabinkarp64.go
+++ b/rabinkarp64/rabinkarp64.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 
 	"github.com/chmduquesne/rollinghash"
+	"github.com/chmduquesne/rollinghash/internal/window"
 )
 
 const Size = 8
@@ -177,17 +178,7 @@ func (d *RabinKarp64) BlockSize() int { return 1 }
 
 // WriteWindow writes the contents of the current window to w.
 func (d *RabinKarp64) WriteWindow(w io.Writer) (n int, err error) {
-	// Copy the older bytes.
-	if d.oldest < len(d.window) {
-		n, err = w.Write(d.window[d.oldest:])
-	}
-	// Then the newer bytes.
-	if err == nil && d.oldest > 0 {
-		var n2 int
-		n2, err = w.Write(d.window[:d.oldest])
-		n += n2
-	}
-	return
+	return window.Write(w, d.window, d.oldest)
 }
 
 // Write appends data to the rolling window and updates the digest.


### PR DESCRIPTION
Here's some refactoring of the common code for dealing with rolling windows.

The first patch factors out the WriteWindow methods to a function in an internal package. The WriteWindow methods are now so small that they get inlined, so callers still do a single function call (not counting the Write calls).

The second factors out the re-arranging, while changing the algorithm to operate in-place (no allocation).