### PR TITLE
Use `Len64` from "math/bits" in `Deg`

### DIFF
--- a/rabinkarp64/polynomials.go
+++ b/rabinkarp64/polynomials.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"math/bits"
 	"strconv"
 )
 
@@ -88,45 +89,7 @@ func (x Pol) Mul(y Pol) Pol {
 
 // Deg returns the degree of the polynomial x. If x is zero, -1 is returned.
 func (x Pol) Deg() int {
-	// the degree of 0 is -1
-	if x == 0 {
-		return -1
-	}
-
-	// see https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog
-
-	r := 0
-	if uint64(x)&0xffffffff00000000 > 0 {
-		x >>= 32
-		r |= 32
-	}
-
-	if uint64(x)&0xffff0000 > 0 {
-		x >>= 16
-		r |= 16
-	}
-
-	if uint64(x)&0xff00 > 0 {
-		x >>= 8
-		r |= 8
-	}
-
-	if uint64(x)&0xf0 > 0 {
-		x >>= 4
-		r |= 4
-	}
-
-	if uint64(x)&0xc > 0 {
-		x >>= 2
-		r |= 2
-	}
-
-	if uint64(x)&0x2 > 0 {
-		x >>= 1
-		r |= 1
-	}
-
-	return r
+	return bits.Len64(uint64(x)) - 1
 }
 
 // String returns the coefficients in hex.


### PR DESCRIPTION
Switches the `Deg` function in `rabinkarp64/polynomials.go` to use `Len64` instead of the bit hacks version.

On my machine, this does not produce much of a speedup for `go run roll/main.go` but does speed up the rabin karp tests from ~23s to ~6s .

## Benches
A small difference, but I did an unpaired t-test and it seems to be real.

Command:
```
hyperfine 'go run roll/main.go -size 2G'
```

- On main branch
  ```
  Time (mean ± σ):      9.293 s ±  0.069 s    [User: 6.782 s, System: 2.563 s]
  Range (min … max):    9.200 s …  9.411 s    10 runs
  ```
- With changes to `Deg`
  ```
  Time (mean ± σ):      9.114 s ±  0.079 s    [User: 6.632 s, System: 2.529 s]
  Range (min … max):    8.981 s …  9.236 s    10 runs
  ```

## Notes
- `math/bits` didn't exist until Go 1.9 ( https://pkg.go.dev/math/bits?tab=versions )
- Tests were done on a relatively new ARM apple macbook so maybe the speedup isn't replicable for other devices

